### PR TITLE
 Run firefox as non-root

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -29,7 +29,12 @@ module MozillaFirefox
 
   def firefox_shellout(command)
     cmd = Mixlib::ShellOut.new(command)
+    # Firefox executable can no longer be run by root
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1323302
+    system("useradd firefox_install")
+    cmd.user="firefox_install"
     cmd.run_command
+    system("userdel firefox_install")
     cmd.stdout.strip
   end
 end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -31,10 +31,14 @@ module MozillaFirefox
     cmd = Mixlib::ShellOut.new(command)
     # Firefox executable can no longer be run by root
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1323302
-    system("useradd firefox_install")
-    cmd.user="firefox_install"
-    cmd.run_command
-    system("userdel firefox_install")
+    if RUBY_PLATFORM =~ /linux/
+      system("useradd firefox_install")
+      cmd.user="firefox_install"
+      cmd.run_command
+      system("userdel firefox_install")
+    else
+      cmd.run_command
+    end
     cmd.stdout.strip
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs Mozilla Firefox browser'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/dhoer/chef-mozilla_firefox'
 issues_url 'https://github.com/dhoer/chef-mozilla_firefox/issues'
-version '3.0.1'
+version '3.0.2'
 
 chef_version '>= 12.6'
 


### PR DESCRIPTION
Linux only.

Due to https://bugzilla.mozilla.org/show_bug.cgi?id=1323302 the firefox
executable can no longer be run by root.  So when chef tries to run
`firefox -v` it gets an error instead of the version.

This change adds a user to run the command as and then deletes the user.