### PR TITLE
Fix chef version & apt update required

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 11.18
+  require_chef_omnibus: 14.12.3
 
 platforms:
   - name: windows-2012r2
@@ -23,6 +23,7 @@ platforms:
 suites:
   - name: default
     run_list:
+      - mozilla_firefox_test::package
       - mozilla_firefox_test
     attributes:
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
       box: dhoer/windows-2012r2
     attributes:
       mozilla_firefox:
-        version: latest
+        version: latest-esr
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-6.8


### PR DESCRIPTION
Chef client 11 is deprecated:
https://docs.chef.io/versions.html#deprecated-products-and-versions

"apt update" is required before Firefox package is installed. I have enabled mozilla_firefox_test::package to execute it.

HTH